### PR TITLE
Add a context menu for location items and add remove location functio…

### DIFF
--- a/src/main/kotlin/org/jetbrains/plugins/template/components/ContextPopupMenu.kt
+++ b/src/main/kotlin/org/jetbrains/plugins/template/components/ContextPopupMenu.kt
@@ -1,0 +1,60 @@
+package org.jetbrains.plugins.template.components
+
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.onClick
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.PopupPositionProvider
+import org.jetbrains.jewel.foundation.theme.JewelTheme
+import org.jetbrains.jewel.ui.component.Icon
+import org.jetbrains.jewel.ui.component.PopupContainer
+import org.jetbrains.jewel.ui.component.Text
+import org.jetbrains.jewel.ui.icon.IconKey
+
+@Composable
+fun ContextPopupMenu(
+    popupPositionProvider: PopupPositionProvider,
+    onDismissRequest: () -> Unit,
+    content: @Composable () -> Unit,
+) {
+    PopupContainer(
+        popupPositionProvider = popupPositionProvider,
+        modifier = Modifier.wrapContentSize(),
+        onDismissRequest = { onDismissRequest() },
+        horizontalAlignment = Alignment.Start
+    ) {
+        content()
+    }
+}
+
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+fun ContextPopupMenuItem(
+    actionText: String,
+    actionIcon: IconKey,
+    onClick: () -> Unit,
+) {
+    Row(
+        modifier = Modifier
+            .widthIn(min = 100.dp)
+            .padding(8.dp)
+            .onClick { onClick() },
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Icon(
+            actionIcon,
+            contentDescription = null,
+            modifier = Modifier.size(16.dp)
+        )
+
+        Spacer(modifier = Modifier.width(8.dp))
+
+        Text(
+            text = actionText,
+            style = JewelTheme.defaultTextStyle
+        )
+    }
+}

--- a/src/main/resources/messages/ComposeTemplate.properties
+++ b/src/main/resources/messages/ComposeTemplate.properties
@@ -9,4 +9,6 @@ weather.app.search.toolbar.menu.add.button.text=Add
 weather.app.search.toolbar.menu.add.button.content.description=Add a place to a watch list.
 weather.app.7days.forecast.title.text=7-day Forecast
 
+weather.app.context.menu.delete.option=Delete
+
 weather.app.clear.button.content.description=Clear


### PR DESCRIPTION
## Description
Added the ability to delete locations from the locations list using a right-click context menu, improving user experience and providing intuitive location management.

## Changes Made

### ✨ Features

- Right-click context menu: Added context menu that appears on right-click for any location item.
- Delete functionality: Users can now delete locations directly from the list.
- Precise positioning: Context menu appears exactly where the user right-clicked.

### 🔧 Technical Implementation

- Implemented right-click detection using onPointerEvent(PointerEventType.Press) with isSecondaryPressed check.
- Added position tracking with onGloballyPositioned and positionInWindow() for accurate popup placement.
- Used PopupContainer with PopupPositionProvider for precise popup positioning.
- Integrated with existing MyLocationsViewModelApi.onDeleteLocation() method.

### 🎨 UI/UX Improvements

- Context menu uses consistent Jewel UI styling with proper theming
- Menu includes delete icon and text for clear user intent
- Popup dismisses on outside click, escape key, or when action is performed
- No interference with existing list selection behavior

### Testing

- Right-click on any location item shows context menu
- Context menu appears at exact cursor position
- Delete action removes location from list
- Popup dismisses correctly after action
- No conflicts with existing list selection functionality- 

### Screenshots/Demo

https://github.com/user-attachments/assets/1fb81b18-5835-4f33-821a-af1abdf1859b

