### PR TITLE
Simplify Jewel / Compose setup in plugin.xml by using 'intellij.platform.compose' umbrella module

### DIFF
--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -4,11 +4,7 @@
     <vendor url="https://www.yourcompany.com">YourCompany</vendor>
 
     <dependencies>
-        <module name="intellij.libraries.skiko"></module>
-        <module name="intellij.libraries.compose.foundation.desktop"></module>
-        <module name="intellij.platform.jewel.foundation"></module>
-        <module name="intellij.platform.jewel.ui"></module>
-        <module name="intellij.platform.jewel.ideLafBridge"></module>
+        <module name="intellij.platform.compose"/>
     </dependencies>
 
     <resource-bundle>messages.ComposeTemplate</resource-bundle>


### PR DESCRIPTION
IDEA 2025.1.4.1 introduces the 'intellij.platform.compose' umbrella module, which bundles all required Jewel and Compose plugin runtime dependencies.

This PR updates plugin.xml to leverage this simplified approach for configuring Jewel/Compose dependencies.